### PR TITLE
Fix .two-col display height issue

### DIFF
--- a/web/demos/anaconda/index.html
+++ b/web/demos/anaconda/index.html
@@ -207,10 +207,13 @@
 
     <section id="final" data-background="../../images/launch-background.png">
       <div class="two-col">
-        <a href="/">
-          <div><img src="../../images/platform-logo-1c-black.svg" alt="That's Platform.sh" class="plain" /></div>
-          <p class="button">View all topics</p>
-        </a>
+        <div>
+          <a href="/">
+            <div><img src="../../images/platform-logo-1c-black.svg" alt="That's Platform.sh" class="plain" /></div>
+            <p class="button">View all topics</p>
+          </a>
+        </div>
+        <div></div>
       </div>
     </section>
 

--- a/web/demos/control-costs/index.html
+++ b/web/demos/control-costs/index.html
@@ -127,10 +127,13 @@
 
     <section id="final" data-background="../../images/launch-background.png">
       <div class="two-col">
-        <a href="/">
-          <div><img src="../../images/platform-logo-1c-black.svg" alt="That's Platform.sh" class="plain" /></div>
-          <p class="button">View all topics</p>
-        </a>
+        <div>
+          <a href="/">
+            <div><img src="../../images/platform-logo-1c-black.svg" alt="That's Platform.sh" class="plain" /></div>
+            <p class="button">View all topics</p>
+          </a>
+        </div>
+        <div></div>
       </div>
     </section>
 

--- a/web/demos/dev-prod/index.html
+++ b/web/demos/dev-prod/index.html
@@ -116,7 +116,7 @@
     </section>
 
     <section>
-      <asciinema-player src="assets/06-new-env.cast"></asciinema-player>		
+      <asciinema-player src="assets/06-new-env.cast"></asciinema-player>
       <p>New environments inherit variables when created.</p>
       <p>Developers don't need to worry about using correct settings.</p>
     </section>
@@ -128,10 +128,13 @@
 
     <section id="final" data-background="../../images/launch-background.png">
       <div class="two-col">
-        <a href="/">
-          <div><img src="../../images/platform-logo-1c-black.svg" alt="That's Platform.sh" class="plain" /></div>
-          <p class="button">View all topics</p>
-        </a>
+        <div>
+          <a href="/">
+            <div><img src="../../images/platform-logo-1c-black.svg" alt="That's Platform.sh" class="plain" /></div>
+            <p class="button">View all topics</p>
+          </a>
+        </div>
+        <div></div>
       </div>
     </section>
 

--- a/web/demos/django-cli/index.html
+++ b/web/demos/django-cli/index.html
@@ -72,7 +72,7 @@
       <asciinema-player src="assets/01-create.cast"></asciinema-player>
       <p>1. Create a new project with the CLI</p>
     </section>
-	
+
     <section>
       <asciinema-player src="assets/02-init.cast"></asciinema-player>
       <p>2. Initialize the new project with a public GitHub repository, using <span class="hljs">platform environment:init</span></p>
@@ -90,10 +90,13 @@
 
     <section id="final" data-background="../../images/launch-background.png">
       <div class="two-col">
-        <a href="/">
-          <div><img src="../../images/platform-logo-1c-black.svg" alt="That's Platform.sh" class="plain" /></div>
-          <p class="button">View all topics</p>
-        </a>
+        <div>
+          <a href="/">
+            <div><img src="../../images/platform-logo-1c-black.svg" alt="That's Platform.sh" class="plain" /></div>
+            <p class="button">View all topics</p>
+          </a>
+        </div>
+        <div></div>
       </div>
     </section>
 

--- a/web/demos/drupal-elasticsearch/index.html
+++ b/web/demos/drupal-elasticsearch/index.html
@@ -130,10 +130,13 @@ if ($platformsh->hasRelationship($relationship_name)) {
 
     <section id="final" data-background="../../images/launch-background.png">
       <div class="two-col">
-        <a href="/">
-          <div><img src="../../images/platform-logo-1c-black.svg" alt="That's Platform.sh" class="plain" /></div>
-          <p class="button">View all topics</p>
-        </a>
+        <div>
+          <a href="/">
+            <div><img src="../../images/platform-logo-1c-black.svg" alt="That's Platform.sh" class="plain" /></div>
+            <p class="button">View all topics</p>
+          </a>
+        </div>
+        <div></div>
       </div>
     </section>
 

--- a/web/demos/drupal-install-cli/index.html
+++ b/web/demos/drupal-install-cli/index.html
@@ -72,7 +72,7 @@
       <asciinema-player src="assets/01-create.cast"></asciinema-player>
       <p>1. Create a new project with the CLI</p>
     </section>
-	
+
     <section>
       <asciinema-player src="assets/02-init.cast"></asciinema-player>
       <p>2. Initialize the new project with a public GitHub repository, using <span class="hljs">platform environment:init</span></p>
@@ -91,10 +91,13 @@
 
     <section id="final" data-background="../../images/launch-background.png">
       <div class="two-col">
-        <a href="/">
-          <div><img src="../../images/platform-logo-1c-black.svg" alt="That's Platform.sh" class="plain" /></div>
-          <p class="button">View all topics</p>
-        </a>
+        <div>
+          <a href="/">
+            <div><img src="../../images/platform-logo-1c-black.svg" alt="That's Platform.sh" class="plain" /></div>
+            <p class="button">View all topics</p>
+          </a>
+        </div>
+        <div></div>
       </div>
     </section>
 

--- a/web/demos/drupal-update/index.html
+++ b/web/demos/drupal-update/index.html
@@ -90,10 +90,13 @@
 
     <section id="final" data-background="../../images/launch-background.png">
       <div class="two-col">
-        <a href="/">
-          <div><img src="../../images/platform-logo-1c-black.svg" alt="That's Platform.sh" class="plain" /></div>
-          <p class="button">View all topics</p>
-        </a>
+        <div>
+          <a href="/">
+            <div><img src="../../images/platform-logo-1c-black.svg" alt="That's Platform.sh" class="plain" /></div>
+            <p class="button">View all topics</p>
+          </a>
+        </div>
+        <div></div>
       </div>
     </section>
 

--- a/web/demos/fast-scale/index.html
+++ b/web/demos/fast-scale/index.html
@@ -99,10 +99,13 @@
 
     <section id="final" data-background="../../images/launch-background.png">
       <div class="two-col">
-        <a href="/">
-          <div><img src="../../images/platform-logo-1c-black.svg" alt="That's Platform.sh" class="plain" /></div>
-          <p class="button">View all topics</p>
-        </a>
+        <div>
+          <a href="/">
+            <div><img src="../../images/platform-logo-1c-black.svg" alt="That's Platform.sh" class="plain" /></div>
+            <p class="button">View all topics</p>
+          </a>
+        </div>
+        <div></div>
       </div>
     </section>
 

--- a/web/demos/github/index.html
+++ b/web/demos/github/index.html
@@ -92,10 +92,13 @@
 
     <section id="final" data-background="../../images/launch-background.png">
       <div class="two-col">
-        <a href="/">
-          <div><img src="../../images/platform-logo-1c-black.svg" alt="That's Platform.sh" class="plain" /></div>
-          <p class="button">View all topics</p>
-        </a>
+        <div>
+          <a href="/">
+            <div><img src="../../images/platform-logo-1c-black.svg" alt="That's Platform.sh" class="plain" /></div>
+            <p class="button">View all topics</p>
+          </a>
+        </div>
+        <div></div>
       </div>
     </section>
 

--- a/web/demos/local-dev/index.html
+++ b/web/demos/local-dev/index.html
@@ -95,10 +95,13 @@
 
     <section id="final" data-background="../../images/launch-background.png">
       <div class="two-col">
-        <a href="/">
-          <div><img src="../../images/platform-logo-1c-black.svg" alt="That's Platform.sh" class="plain" /></div>
-          <p class="button">View all topics</p>
-        </a>
+        <div>
+          <a href="/">
+            <div><img src="../../images/platform-logo-1c-black.svg" alt="That's Platform.sh" class="plain" /></div>
+            <p class="button">View all topics</p>
+          </a>
+        </div>
+        <div></div>
       </div>
     </section>
 

--- a/web/demos/microservices/index.html
+++ b/web/demos/microservices/index.html
@@ -137,12 +137,15 @@
       <p style="margin-top: 0;">Mix and match any supported language as you please.</p>
     </section>
 
-    <section id="final" data-background="../../images/launch-background.png">
+    <<section id="final" data-background="../../images/launch-background.png">
       <div class="two-col">
-        <a href="/">
-          <div><img src="../../images/platform-logo-1c-black.svg" alt="That's Platform.sh" class="plain" /></div>
-          <p class="button">View all topics</p>
-        </a>
+        <div>
+          <a href="/">
+            <div><img src="../../images/platform-logo-1c-black.svg" alt="That's Platform.sh" class="plain" /></div>
+            <p class="button">View all topics</p>
+          </a>
+        </div>
+        <div></div>
       </div>
     </section>
 

--- a/web/demos/mistakes/index.html
+++ b/web/demos/mistakes/index.html
@@ -66,10 +66,13 @@
 
     <section id="final" data-background="../../images/launch-background.png">
       <div class="two-col">
-        <a href="/">
-          <div><img src="../../images/platform-logo-1c-black.svg" alt="That's Platform.sh" class="plain" /></div>
-          <p class="button">View all topics</p>
-        </a>
+        <div>
+          <a href="/">
+            <div><img src="../../images/platform-logo-1c-black.svg" alt="That's Platform.sh" class="plain" /></div>
+            <p class="button">View all topics</p>
+          </a>
+        </div>
+        <div></div>
       </div>
     </section>
 

--- a/web/demos/newtech/index.html
+++ b/web/demos/newtech/index.html
@@ -63,23 +63,23 @@
     <section id="title-slide" data-background-color="#4786ff">
       <h1>Try new technologies<br />and architectures</h1>
     </section>
-	
+
     <section>
       <blockquote>I'd like to test Elasticsearch with my app.'</blockquote>
     </section>
-	
+
 <!--
     <section>
       <img src="assets/1-user-menu.png" alt="Go to the user menu in the top right of the screen." class="screenshot" />
       <p>That's easy. Just go to your user page...</p>
     </section>
 -->
-	
+
     <section>
        <img src="assets/01-elasticsearch-branch.png" alt="Use the UI to make a new elasticsearch branch" class="screenshot">
        <p>To test a new technology, start by making a new branch.</p>
     </section>
-	
+
     <section>
       <asciinema-player src="assets/02-services.cast"></asciinema-player>
 		  <p>On the new branch, add the Elasticsearch service to<br />your <code>services.yaml</code> file.</p>
@@ -124,10 +124,13 @@
 
     <section id="final" data-background="../../images/launch-background.png">
       <div class="two-col">
-        <a href="/">
-          <div><img src="../../images/platform-logo-1c-black.svg" alt="That's Platform.sh" class="plain" /></div>
-          <p class="button">View all topics</p>
-        </a>
+        <div>
+          <a href="/">
+            <div><img src="../../images/platform-logo-1c-black.svg" alt="That's Platform.sh" class="plain" /></div>
+            <p class="button">View all topics</p>
+          </a>
+        </div>
+        <div></div>
       </div>
     </section>
 

--- a/web/demos/operating-scale/index.html
+++ b/web/demos/operating-scale/index.html
@@ -116,10 +116,13 @@
 
     <section id="final" data-background="../../images/launch-background.png">
       <div class="two-col">
-        <a href="/">
-          <div><img src="../../images/platform-logo-1c-black.svg" alt="That's Platform.sh" class="plain" /></div>
-          <p class="button">View all topics</p>
-        </a>
+        <div>
+          <a href="/">
+            <div><img src="../../images/platform-logo-1c-black.svg" alt="That's Platform.sh" class="plain" /></div>
+            <p class="button">View all topics</p>
+          </a>
+        </div>
+        <div></div>
       </div>
     </section>
 

--- a/web/demos/pentest/index.html
+++ b/web/demos/pentest/index.html
@@ -67,10 +67,13 @@
 
     <section id="final" data-background="../../images/launch-background.png">
       <div class="two-col">
-        <a href="/">
-          <div><img src="../../images/platform-logo-1c-black.svg" alt="That's Platform.sh" class="plain" /></div>
-          <p class="button">View all topics</p>
-        </a>
+        <div>
+          <a href="/">
+            <div><img src="../../images/platform-logo-1c-black.svg" alt="That's Platform.sh" class="plain" /></div>
+            <p class="button">View all topics</p>
+          </a>
+        </div>
+        <div></div>
       </div>
     </section>
 

--- a/web/demos/platform-overview/index.html
+++ b/web/demos/platform-overview/index.html
@@ -128,7 +128,7 @@
       <video width="100%" data-autoplay muted playsinline>
         <source src="assets/13.mp4" type="video/mp4">
       </video>
-    </section>												
+    </section>
     <section>
       <video width="100%" data-autoplay muted playsinline>
         <source src="assets/14.mp4" type="video/mp4">
@@ -148,14 +148,17 @@
       <video width="100%" data-autoplay muted playsinline>
         <source src="assets/17.mp4" type="video/mp4">
       </video>
-    </section>			
+    </section>
 
     <section id="final" data-background="../../images/launch-background.png">
       <div class="two-col">
-        <a href="/">
-          <div><img src="../../images/platform-logo-1c-black.svg" alt="That's Platform.sh" class="plain" /></div>
-          <p class="button">View all topics</p>
-        </a>
+        <div>
+          <a href="/">
+            <div><img src="../../images/platform-logo-1c-black.svg" alt="That's Platform.sh" class="plain" /></div>
+            <p class="button">View all topics</p>
+          </a>
+        </div>
+        <div></div>
       </div>
     </section>
 

--- a/web/demos/real-services/index.html
+++ b/web/demos/real-services/index.html
@@ -127,10 +127,13 @@
 
     <section id="final" data-background="../../images/launch-background.png">
       <div class="two-col">
-        <a href="/">
-          <div><img src="../../images/platform-logo-1c-black.svg" alt="That's Platform.sh" class="plain" /></div>
-          <p class="button">View all topics</p>
-        </a>
+        <div>
+          <a href="/">
+            <div><img src="../../images/platform-logo-1c-black.svg" alt="That's Platform.sh" class="plain" /></div>
+            <p class="button">View all topics</p>
+          </a>
+        </div>
+        <div></div>
       </div>
     </section>
 

--- a/web/demos/reduce-devops/index.html
+++ b/web/demos/reduce-devops/index.html
@@ -67,10 +67,13 @@
 
     <section id="final" data-background="../../images/launch-background.png">
       <div class="two-col">
-        <a href="/">
-          <div><img src="../../images/platform-logo-1c-black.svg" alt="That's Platform.sh" class="plain" /></div>
-          <p class="button">View all topics</p>
-        </a>
+        <div>
+          <a href="/">
+            <div><img src="../../images/platform-logo-1c-black.svg" alt="That's Platform.sh" class="plain" /></div>
+            <p class="button">View all topics</p>
+          </a>
+        </div>
+        <div></div>
       </div>
     </section>
 
@@ -104,7 +107,7 @@
         Build code on git push
         YAML-based config
     </div>
-   
+
   </div>
 
 </div>

--- a/web/demos/saas/index.html
+++ b/web/demos/saas/index.html
@@ -152,10 +152,13 @@
 
     <section id="final" data-background="../../images/launch-background.png">
       <div class="two-col">
-        <a href="https://demos.platform.sh/">
-          <div><img src="../../images/platform-logo-1c-black.svg" alt="That's Platform.sh" class="plain" /></div>
-          <p class="button">View all topics</p>
-        </a>
+        <div>
+          <a href="/">
+            <div><img src="../../images/platform-logo-1c-black.svg" alt="That's Platform.sh" class="plain" /></div>
+            <p class="button">View all topics</p>
+          </a>
+        </div>
+        <div></div>
       </div>
     </section>
 

--- a/web/demos/scrum/index.html
+++ b/web/demos/scrum/index.html
@@ -120,10 +120,13 @@
 
     <section id="final" data-background="../../images/launch-background.png">
       <div class="two-col">
-        <a href="/">
-          <div><img src="../../images/platform-logo-1c-black.svg" alt="That's Platform.sh" class="plain" /></div>
-          <p class="button">View all topics</p>
-        </a>
+        <div>
+          <a href="/">
+            <div><img src="../../images/platform-logo-1c-black.svg" alt="That's Platform.sh" class="plain" /></div>
+            <p class="button">View all topics</p>
+          </a>
+        </div>
+        <div></div>
       </div>
     </section>
 

--- a/web/demos/security/index.html
+++ b/web/demos/security/index.html
@@ -181,10 +181,13 @@
 
     <section id="final" data-background="../../images/launch-background.png">
       <div class="two-col">
-        <a href="/">
-          <div><img src="../../images/platform-logo-1c-black.svg" alt="That's Platform.sh" class="plain" /></div>
-          <p class="button">View all topics</p>
-        </a>
+        <div>
+          <a href="/">
+            <div><img src="../../images/platform-logo-1c-black.svg" alt="That's Platform.sh" class="plain" /></div>
+            <p class="button">View all topics</p>
+          </a>
+        </div>
+        <div></div>
       </div>
     </section>
 

--- a/web/demos/team-scale/index.html
+++ b/web/demos/team-scale/index.html
@@ -107,10 +107,13 @@
 
     <section id="final" data-background="../../images/launch-background.png">
       <div class="two-col">
-        <a href="/">
-          <div><img src="../../images/platform-logo-1c-black.svg" alt="That's Platform.sh" class="plain" /></div>
-          <p class="button">View all topics</p>
-        </a>
+        <div>
+          <a href="/">
+            <div><img src="../../images/platform-logo-1c-black.svg" alt="That's Platform.sh" class="plain" /></div>
+            <p class="button">View all topics</p>
+          </a>
+        </div>
+        <div></div>
       </div>
     </section>
 

--- a/web/demos/upgrades/index.html
+++ b/web/demos/upgrades/index.html
@@ -135,10 +135,13 @@
 
     <section id="final" data-background="../../images/launch-background.png">
       <div class="two-col">
-        <a href="/">
-          <div><img src="../../images/platform-logo-1c-black.svg" alt="That's Platform.sh" class="plain" /></div>
-          <p class="button">View all topics</p>
-        </a>
+        <div>
+          <a href="/">
+            <div><img src="../../images/platform-logo-1c-black.svg" alt="That's Platform.sh" class="plain" /></div>
+            <p class="button">View all topics</p>
+          </a>
+        </div>
+        <div></div>
       </div>
     </section>
 

--- a/web/theme.css
+++ b/web/theme.css
@@ -372,9 +372,14 @@ body {
  *********************************************/
 
 .two-col {
-    display: grid;
-    grid-template-columns: 1fr 1fr;
+    display: flex;
+    flex: 2;
+    justify-content: space-around;
     align-items: center;
+}
+
+.two-col > div {
+    flex: 1;
 }
 
 .two-col.top-align {


### PR DESCRIPTION
On Chrome, the SVG images within the `.two-col` class display with 0 height. This results in the images not being displayed: ![Broken Image Columns](https://www.dropbox.com/s/a2uzromfciwdkdj/Screenshot%202019-05-01%2022.50.43.png?raw=1)

This fix uses a div with `flex: 2` with the nested divs having `flex: 1` to create a two-column layout with images displaying the correct height: ![Fixed Image Columns](https://www.dropbox.com/s/u54i3e9jctbrncv/Screenshot%202019-05-01%2022.49.50.png?raw=1).

I also tested it in Safari. The particular page that this occurred on: http://pr-1-djjnuwy-rnrboohk7khf4.eu-2.platformsh.site/demos/drupal-update/index.html#/2