### PR TITLE
Fix link for cli demo.

### DIFF
--- a/web/demos/metadata.json
+++ b/web/demos/metadata.json
@@ -37,7 +37,7 @@
             "imageSlug": "connected"
         },
         {
-            "demoSlug": "drupal-cli",
+            "demoSlug": "drupal-install-cli",
             "gridTitle": "Install Drupal with the CLI",
             "fullTitle": "",
             "imageSlug": "speed"


### PR DESCRIPTION
Copied the incorrect link for the "Install Drupal via the CLI" demo. This should fix that.